### PR TITLE
feat: detect bundled scripts, excessive length, and non-markdown siblings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use serde_sarif::sarif;
 use walkdir::WalkDir;
 
 mod rules;
-use rules::{Issue, SuspicionLevel, Rule, invisible_chars, non_printable, html_comments, excessive_whitespace, suspicious_keywords, unicode_homoglyphs, mixed_scripts, url_encoding, excessive_backticks, base64_encoded, high_entropy, frontmatter_hooks, inline_commands, Severity, compute_suspicion_level};
+use rules::{Issue, SuspicionLevel, Rule, invisible_chars, non_printable, html_comments, excessive_whitespace, suspicious_keywords, unicode_homoglyphs, mixed_scripts, url_encoding, excessive_backticks, base64_encoded, high_entropy, frontmatter_hooks, inline_commands, bundled_scripts, excessive_length, Severity, compute_suspicion_level};
 
 #[derive(Parser)]
 #[command(name = "skill-issues")]
@@ -49,6 +49,10 @@ struct Cli {
     /// Also scan for confusable/suspicious spaces and fillers (e.g. NBSP, thin space, hangul filler)
     #[arg(long)]
     include_confusable_spaces: bool,
+
+    /// Skip scanning for non-markdown sibling files alongside skill documents
+    #[arg(long)]
+    no_sibling_check: bool,
 }
 
 #[derive(ValueEnum, Clone, Debug, Serialize, Deserialize)]
@@ -124,6 +128,8 @@ impl Linter {
             Box::new(high_entropy::HighEntropyRule),
             Box::new(frontmatter_hooks::FrontmatterHooksRule),
             Box::new(inline_commands::InlineCommandsRule),
+            Box::new(bundled_scripts::BundledScriptsRule),
+            Box::<excessive_length::ExcessiveLengthRule>::default(),
         ];
 
         Self { rules }
@@ -175,6 +181,99 @@ fn is_markdown_file(path: &Path) -> bool {
         .is_some_and(|e| matches!(e.to_lowercase().as_str(), "md" | "markdown"))
 }
 
+/// Scans sibling and child directories of markdown files for non-markdown files.
+///
+/// A skill bundle that includes executable scripts or other files alongside the
+/// markdown is suspicious — the skill may reference and execute these bundled
+/// files in ways invisible to plain-text scanners.
+///
+/// Returns `FileResult` entries for each directory that contains non-markdown
+/// files alongside markdown files.
+fn find_non_markdown_siblings(scan_root: &Path, markdown_paths: &[PathBuf]) -> Vec<FileResult> {
+    use std::collections::HashSet;
+
+    let mut results: Vec<FileResult> = Vec::new();
+
+    // Collect all directories that contain at least one markdown file
+    let markdown_dirs: HashSet<&Path> = markdown_paths
+        .iter()
+        .filter_map(|p| p.parent())
+        .collect();
+
+    // Walk all files under scan_root, excluding ignored dirs
+    let mut non_md_by_parent: std::collections::HashMap<PathBuf, Vec<PathBuf>> =
+        std::collections::HashMap::new();
+
+    // Collect all non-markdown files first to avoid lifetime issues
+    let non_md_files: Vec<(PathBuf, PathBuf)> = WalkDir::new(scan_root)
+        .into_iter()
+        .filter_entry(|e| !is_ignored_dir(e))
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| !is_markdown_file(e.path()))
+        .filter_map(|entry| {
+            let parent = entry.path().parent()?.to_path_buf();
+            Some((parent, entry.path().to_path_buf()))
+        })
+        .filter(|(parent, _file)| {
+            let mut current: Option<&Path> = Some(parent.as_path());
+            while let Some(dir) = current {
+                if markdown_dirs.contains(dir) {
+                    return true;
+                }
+                current = dir.parent();
+            }
+            false
+        })
+        .collect();
+
+    for (parent, file) in non_md_files {
+        non_md_by_parent
+            .entry(parent)
+            .or_default()
+            .push(file);
+    }
+
+    // Build FileResult entries grouped by immediate parent directory
+    let scan_root_str = scan_root.display().to_string();
+    for (parent_dir, files) in &non_md_by_parent {
+        let mut issues: Vec<Issue> = files
+            .iter()
+            .map(|f| {
+                let relative = f
+                    .strip_prefix(&scan_root_str)
+                    .unwrap_or(f)
+                    .display()
+                    .to_string();
+                Issue {
+                    severity: Severity::Warning,
+                    line: 0,
+                    column: None,
+                    message: format!(
+                        "Non-markdown file '{relative}' found alongside skill document — \
+                         bundled files may contain hidden logic not visible to scanners"
+                    ),
+                    rule: "non-markdown-siblings".to_string(),
+                }
+            })
+            .collect();
+        // Sort issues for deterministic output
+        issues.sort_by(|a, b| a.message.cmp(&b.message));
+
+        if !issues.is_empty() {
+            results.push(FileResult {
+                path: parent_dir.display().to_string(),
+                issues,
+                suspicion_level: None,
+                total_invisible_codepoints: None,
+                longest_consecutive_run: None,
+            });
+        }
+    }
+
+    results
+}
+
 const fn severity_to_sarif_level(severity: &Severity) -> sarif::ResultLevel {
     match severity {
         Severity::Error => sarif::ResultLevel::Error,
@@ -197,6 +296,9 @@ fn generate_sarif(file_results: &[FileResult]) -> sarif::Sarif {
         "high-entropy",
         "frontmatter-hooks",
         "inline-commands",
+        "bundled-scripts",
+        "excessive-length",
+        "non-markdown-siblings",
     ]
     .iter()
     .map(|id| {
@@ -379,7 +481,7 @@ fn main() -> Result<()> {
     };
 
     // Scan files in parallel — each file is read and linted independently
-    let file_results: Vec<FileResult> = paths
+    let mut file_results: Vec<FileResult> = paths
         .par_iter()
         .filter_map(|path| {
             let content = fs::read_to_string(path).ok()?;
@@ -402,6 +504,12 @@ fn main() -> Result<()> {
             })
         })
         .collect();
+
+    // Detect non-markdown files in sibling/child directories of markdown files
+    if !cli.no_sibling_check {
+        let sibling_results = find_non_markdown_siblings(&cli.path, &paths);
+        file_results.extend(sibling_results);
+    }
 
     // Aggregate error/warning counts from parallel results
     let (total_errors, total_warnings) = file_results.iter().fold((0, 0), |(errs, warns), fr| {
@@ -494,6 +602,33 @@ High entropy: dQw4w9WgXcQvXhGGXTthx6z8JG4Z3L6vX9T3z7K9P8N
         assert!(rules_found.contains(&"excessive-backticks"));
         assert!(rules_found.contains(&"invisible-characters"));
         assert!(rules_found.contains(&"high-entropy"));
+    }
+
+    #[test]
+    fn linter_detects_bundled_script_references() {
+        let linter = Linter::new(LinterConfig {
+            max_empty_lines: 3,
+            include_cc: false,
+            include_confusable_spaces: false,
+        });
+        let content = "Run `./setup.sh` and then `./install.py` to begin.\n";
+        let issues = linter.lint(content);
+        let rules_found: Vec<&str> = issues.iter().map(|i| i.rule.as_str()).collect();
+        assert!(rules_found.contains(&"bundled-scripts"));
+        assert!(issues.len() >= 2);
+    }
+
+    #[test]
+    fn linter_detects_excessive_length() {
+        let linter = Linter::new(LinterConfig {
+            max_empty_lines: 3,
+            include_cc: false,
+            include_confusable_spaces: false,
+        });
+        let content = "line\n".repeat(600);
+        let issues = linter.lint(&content);
+        let rules_found: Vec<&str> = issues.iter().map(|i| i.rule.as_str()).collect();
+        assert!(rules_found.contains(&"excessive-length"));
     }
 
     #[test]

--- a/src/rules/bundled_scripts.rs
+++ b/src/rules/bundled_scripts.rs
@@ -1,0 +1,229 @@
+use regex::Regex;
+
+use super::{Issue, Rule, Severity};
+
+/// Detects references to local bundled scripts or executables in skill markdown.
+///
+/// Overtly malicious skills often work by referencing an external script that
+/// lives alongside the markdown, rather than embedding malicious instructions
+/// directly in the prompt. This makes them invisible to plain-text scanners.
+///
+/// Reference: <https://blog.trailofbits.com/2026/06/03/the-sorry-state-of-skill-distribution/>
+pub struct BundledScriptsRule;
+
+impl Rule for BundledScriptsRule {
+    fn name(&self) -> &'static str {
+        "bundled-scripts"
+    }
+
+    fn check(&self, content: &str) -> Vec<Issue> {
+        let mut issues = Vec::new();
+
+        // Match common patterns for local script/executable file references.
+        // Covers: relative paths (./ ../ .\), home-relative (~/), Windows drive
+        // letters (C:\), and common absolute system paths (/usr/, /tmp/, etc.).
+        let re = Regex::new(
+            r#"(?i)(?:\.{1,2}[/\\]|~/|[A-Za-z]:[/\\]|[/\\](?:home|usr|tmp|etc|var)[/\\])[^\s`'"\)<>]*?\.(?:sh|py|js|rb|pl|bat|ps1|exe|bin|elf|app|cmd|vbs|wsf|jar|php|go|ts|mjs|cjs)\b"#
+        ).expect("invalid regex for bundled script pattern");
+
+        for (line_num, line) in content.lines().enumerate() {
+            for mat in re.find_iter(line) {
+                issues.push(Issue {
+                    severity: Severity::Warning,
+                    line: line_num + 1,
+                    column: Some(mat.start()),
+                    message: format!(
+                        "Reference to bundled script or executable: '{}' — skill may execute \
+                         external code not visible to plain-text scanners",
+                        mat.as_str()
+                    ),
+                    rule: self.name().to_string(),
+                });
+            }
+        }
+
+        issues
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check(content: &str) -> Vec<Issue> {
+        BundledScriptsRule.check(content)
+    }
+
+    #[test]
+    fn clean_content_no_issues() {
+        let content = "# My Skill\n\nThis skill helps with markdown formatting.\n";
+        assert!(check(content).is_empty());
+    }
+
+    #[test]
+    fn detects_relative_shell_script() {
+        let content = "Run `./setup.sh` to configure the environment.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("setup.sh")),
+            "should detect ./setup.sh, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn detects_python_script() {
+        let content = "Execute `./install.py` first.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("install.py")),
+            "should detect install.py, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn detects_javascript_script() {
+        let content = "The helper at `./helpers/init.js` does setup work.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("init.js")),
+            "should detect init.js, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn detects_parent_dir_script() {
+        let content = "../malicious.sh is run before anything else.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("malicious.sh")),
+            "should detect ../malicious.sh, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn detects_absolute_path_script() {
+        let content = "Check `/usr/local/bin/helper.py` for configuration.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("helper.py")),
+            "should detect absolute path, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn detects_home_relative_script() {
+        let content = "Source `~/install.sh` to set up.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("install.sh")),
+            "should detect ~/install.sh, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn detects_tmp_path_script() {
+        let content = "It uses /tmp/exploit.py for temporary work.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("exploit.py")),
+            "should detect /tmp/exploit.py, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn detects_quoted_script_reference() {
+        let content = r#"The command "./helper.js" runs the tool."#;
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("helper.js")),
+            "should detect quoted script, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn detects_markdown_link_to_script() {
+        let content = "See [the script](./init.sh) for setup.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("init.sh")),
+            "should detect markdown link, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn detects_ruby_script() {
+        let content = "Run `./tasks/deploy.rb` to deploy.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("deploy.rb")),
+            "should detect deploy.rb, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn detects_batch_script() {
+        let content = r"On Windows, use `.\setup.bat`.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("setup.bat")),
+            "should detect setup.bat, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn detects_powershell_script() {
+        let content = "The PS script is `./Configure.ps1`.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("Configure.ps1")),
+            "should detect Configure.ps1, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn detects_executable_binary() {
+        let content = "Download `./tool.bin` and run it.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("tool.bin")),
+            "should detect tool.bin, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn no_false_positive_on_markdown_links() {
+        let content =
+            "See [documentation](./README.md) for details.\nSee [config](./config.yaml) for \
+             options.";
+        assert!(check(content).is_empty());
+    }
+
+    #[test]
+    fn no_false_positive_on_normal_text() {
+        let content =
+            "We use shell scripts for automation.\nPython is great for scripting.\njavascript \
+             runs in the browser.\nThe file extension .sh is common.";
+        assert!(check(content).is_empty());
+    }
+
+    #[test]
+    fn detects_multiple_references() {
+        let content = "Run `./setup.sh` then `./cleanup.py`.";
+        let issues = check(content);
+        assert!(
+            issues.len() >= 2,
+            "expected at least 2 issues, got {}: {issues:?}",
+            issues.len()
+        );
+    }
+
+    #[test]
+    fn detects_deeply_nested_relative_path() {
+        let content = "Execute `../../../scripts/evil.sh`.";
+        let issues = check(content);
+        assert!(
+            issues.iter().any(|i| i.message.contains("evil.sh")),
+            "should detect deeply nested path, got: {issues:?}"
+        );
+    }
+}

--- a/src/rules/excessive_length.rs
+++ b/src/rules/excessive_length.rs
@@ -1,0 +1,107 @@
+use super::{Issue, Rule, Severity};
+
+/// Warns when a skill markdown file exceeds a threshold line count.
+///
+/// Skill marketplaces often truncate long files, which is a known vector for
+/// hiding exploits. Even locally, oversized skills are harder to audit and
+/// may indicate bundled payloads or obfuscation attempts.
+///
+/// Default threshold: 500 lines. This catches abnormally large skills while
+/// allowing reasonably detailed documentation.
+pub struct ExcessiveLengthRule {
+    pub max_lines: usize,
+}
+
+impl ExcessiveLengthRule {
+    pub const fn new() -> Self {
+        Self { max_lines: 500 }
+    }
+}
+
+impl Default for ExcessiveLengthRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for ExcessiveLengthRule {
+    fn name(&self) -> &'static str {
+        "excessive-length"
+    }
+
+    fn check(&self, content: &str) -> Vec<Issue> {
+        let mut issues = Vec::new();
+        let line_count = content.lines().count();
+
+        if line_count > self.max_lines {
+            issues.push(Issue {
+                severity: Severity::Warning,
+                line: line_count,
+                column: None,
+                message: format!(
+                    "File has {line_count} lines (threshold: {}) — oversized files may hide \
+                     bundled payloads or obfuscated content",
+                    self.max_lines
+                ),
+                rule: self.name().to_string(),
+            });
+        }
+
+        issues
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_file_no_issue() {
+        let rule = ExcessiveLengthRule::new();
+        let content = "# Title\n\nA short skill file.\n";
+        assert!(rule.check(content).is_empty());
+    }
+
+    #[test]
+    fn at_threshold_no_issue() {
+        let rule = ExcessiveLengthRule { max_lines: 500 };
+        let content = "line\n".repeat(500);
+        assert!(rule.check(&content).is_empty());
+    }
+
+    #[test]
+    fn over_threshold_warns() {
+        let rule = ExcessiveLengthRule { max_lines: 500 };
+        let content = "line\n".repeat(501);
+        let issues = rule.check(&content);
+        assert!(!issues.is_empty());
+        let issue = &issues[0];
+        assert!(issue.message.contains("501"));
+        assert!(issue.severity == Severity::Warning);
+    }
+
+    #[test]
+    fn severely_oversized_warns() {
+        let rule = ExcessiveLengthRule { max_lines: 500 };
+        let content = "line\n".repeat(2000);
+        let issues = rule.check(&content);
+        assert!(!issues.is_empty());
+        let issue = &issues[0];
+        assert!(issue.message.contains("2000"));
+    }
+
+    #[test]
+    fn custom_threshold() {
+        let rule = ExcessiveLengthRule { max_lines: 100 };
+        let content = "line\n".repeat(101);
+        let issues = rule.check(&content);
+        assert!(!issues.is_empty());
+        assert!(issues[0].message.contains("100"));
+    }
+
+    #[test]
+    fn empty_file_no_issue() {
+        let rule = ExcessiveLengthRule::new();
+        assert!(rule.check("").is_empty());
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 pub mod base64_encoded;
+pub mod bundled_scripts;
 pub mod excessive_backticks;
+pub mod excessive_length;
 pub mod excessive_whitespace;
 pub mod frontmatter_hooks;
 pub mod high_entropy;


### PR DESCRIPTION
## Summary

Implements the feature requested in #6: detection of bundled code referenced in skills.

### New rules

- **`bundled-scripts`** (warning): Detects references to local script/executable files (`.sh`, `.py`, `.js`, `.rb`, `.bat`, `.ps1`, `.exe`, etc.) via path patterns in markdown content. Flags references like `./setup.sh`, `../evil.py`, `~/install.sh`, `/tmp/exploit.py`, etc. that may indicate a skill executing external code invisible to plain-text scanners.

- **`excessive-length`** (warning): Warns when a skill markdown file exceeds 500 lines. Oversized skill files are harder to audit and may hide bundled payloads or obfuscated content.

### Sibling file detection

- When scanning a directory tree, flags non-markdown files found in sibling/child directories of skill markdown documents. This catches skill bundles that include executable scripts alongside the markdown.
- Added `--no-sibling-check` CLI flag to disable this behavior.

### Other changes

- New rules and sibling check are wired into SARIF output
- All existing tests pass; new tests added for each feature

Refs #6