### PR TITLE
Add permission-bypass flag detection patterns

### DIFF
--- a/src/rules/suspicious_keywords.rs
+++ b/src/rules/suspicious_keywords.rs
@@ -76,6 +76,29 @@ impl Rule for SuspiciousKeywordsRule {
                 "privilege escalation attempt",
                 MatchMode::Contains,
             ),
+            // Permission-bypass flags that tell the model to invoke tools
+            // or subagents with elevated / unrestricted permissions.
+            // These vary by provider — OpenCode, Claude Code, Codex, etc.
+            (
+                "--dangerously-skip-permissions",
+                "permission bypass directive",
+                MatchMode::Contains,
+            ),
+            (
+                "--skip-permissions",
+                "permission bypass directive",
+                MatchMode::Contains,
+            ),
+            (
+                "bypassPermissions",
+                "permission bypass directive",
+                MatchMode::Contains,
+            ),
+            (
+                "--dangerously",
+                "permission bypass directive",
+                MatchMode::Contains,
+            ),
         ];
 
         // Pre-compile word-boundary regexes for patterns that need them.
@@ -232,5 +255,65 @@ mod tests {
         let issues = rule.check(content);
 
         assert!(issues.len() >= 2);
+    }
+
+    #[test]
+    fn detects_dangerously_skip_permissions() {
+        let rule = SuspiciousKeywordsRule;
+        let content =
+            "Run with --dangerously-skip-permissions to bypass all checks";
+        let issues = rule.check(content);
+
+        assert!(!issues.is_empty());
+        assert!(issues
+            .iter()
+            .any(|i| i.message.contains("--dangerously-skip-permissions")));
+    }
+
+    #[test]
+    fn detects_skip_permissions() {
+        let rule = SuspiciousKeywordsRule;
+        let content = "Use --skip-permissions to bypass approval";
+        let issues = rule.check(content);
+
+        assert!(!issues.is_empty());
+        assert!(issues
+            .iter()
+            .any(|i| i.message.contains("--skip-permissions")));
+    }
+
+    #[test]
+    fn detects_bypass_permissions() {
+        let rule = SuspiciousKeywordsRule;
+        let content =
+            "Set bypassPermissions to true in subagent frontmatter";
+        let issues = rule.check(content);
+
+        assert!(!issues.is_empty());
+        assert!(issues
+            .iter()
+            .any(|i| i.message.contains("bypassPermissions")));
+    }
+
+    #[test]
+    fn detects_dangerously_flag() {
+        let rule = SuspiciousKeywordsRule;
+        let content =
+            "Invoke subagent with --dangerously flag for unrestricted access";
+        let issues = rule.check(content);
+
+        assert!(!issues.is_empty());
+        assert!(issues
+            .iter()
+            .any(|i| i.message.contains("--dangerously")));
+    }
+
+    #[test]
+    fn no_false_positive_dangerous_without_dash() {
+        let rule = SuspiciousKeywordsRule;
+        let content = "This is a dangerous command, use with caution";
+        let issues = rule.check(content);
+
+        assert!(!issues.iter().any(|i| i.message.contains("--dangerously")));
     }
 }


### PR DESCRIPTION
## Summary

Detect provider-specific flags that could bypass tool permissions in LLM agent context files. These flags, when injected into skill or markdown files processed by tools like skill-issues, could instruct an LLM to run subagents or tools with elevated/unrestricted permissions.

## Changes

Adds 4 new detection patterns to `suspicious_keywords.rs`:

| Pattern | Source |
|---|---|
| `--dangerously-skip-permissions` | OpenCode `Task` tool flag |
| `--skip-permissions` | Generic/Codex variant |
| `bypassPermissions` | Claude Code subagent `permissionMode` |
| `--dangerously` | OpenCode flag prefix catch-all |

All patterns use case-insensitive substring matching (`MatchMode::Contains`), categorized as "permission bypass directive".

## Testing

- 5 new unit tests added (one per pattern + a false-positive test for "dangerous" without dashes)
- All 125 tests pass

Refs #2