### PR TITLE
docs: add Non-Goals section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Skill files are markdown documents that define behaviors and capabilities for AI
 This tool is extremely conservative. It's essentially looking for ASCII markdown files with some allowance for emojis.
 It's unlikely to be friendly for languages other than English.
 
+`skill-issues` performs only simple, static, lint-based checks on the primary skill files (SKILL.md and related markdown). It does not execute, decode, modify, or otherwise interpret file contents beyond pattern matching.
+
+## Non-Goals
+
+The following are explicitly out of scope and will not be implemented:
+
+- **Secret/credential scanning** — detection of API keys, tokens, private keys, or passwords.
+- **Script analysis** — scanning bundled `.py`, `.sh`, `.js`, or `.ts` files in `scripts/` directories for dangerous patterns (HTTP exfiltration, `eval`, credential access, config modification).
+- **Content-aware decoding** — decoding base64 or Unicode tag blocks to inspect their decoded content. Only the presence of encoded strings is detected, not what they contain.
+- **Structural attack detection** — symlink resolution, test file RCE, npm lifecycle hooks, or image metadata injection.
+- **URL extraction and classification** — extracting URLs from skill content or checking domains against allowlists.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Documents functionality that is explicitly out of scope for `skill-issues`:

- **Secret/credential scanning** — no API key, token, or password detection
- **Script analysis** — no scanning of bundled scripts in `scripts/` directories
- **Content-aware decoding** — detects presence of encoded strings only, does not decode/inspect content
- **Structural attack detection** — no symlink, test file, npm hook, or image metadata checks
- **URL extraction/classification** — no URL extraction or domain allowlisting

This clarifies that `skill-issues` is a simple, static, lint-based tool that focuses on pattern matching within primary skill markdown files and does not execute, decode, modify, or interpret file contents beyond pattern matching.

Refs #5